### PR TITLE
Update to GHC 9.8.1

### DIFF
--- a/System/Metrics.hs
+++ b/System/Metrics.hs
@@ -68,7 +68,9 @@ module System.Metrics
     , Value(..)
     ) where
 
+#if __GLASGOW_HASKELL__ < 808
 import Control.Applicative ((<$>))
+#endif
 import Control.Monad (forM)
 import Data.Int (Int64)
 import qualified Data.IntMap.Strict as IM
@@ -513,26 +515,41 @@ emptyRTSStats = Stats.RTSStats
     , cpu_ns                               = 0
     , elapsed_ns                           = 0
     , gc                                   = emptyGCDetails
+# if MIN_VERSION_base(4,14,0)
+    , nonmoving_gc_sync_cpu_ns             = 0
+    , nonmoving_gc_sync_elapsed_ns         = 0
+    , nonmoving_gc_sync_max_elapsed_ns     = 0
+    , nonmoving_gc_cpu_ns                  = 0
+    , nonmoving_gc_elapsed_ns              = 0
+    , nonmoving_gc_max_elapsed_ns          = 0
+# endif
     }
 
 emptyGCDetails :: Stats.GCDetails
 emptyGCDetails = Stats.GCDetails
-    { gcdetails_gen                       = 0
-    , gcdetails_threads                   = 0
-    , gcdetails_allocated_bytes           = 0
-    , gcdetails_live_bytes                = 0
-    , gcdetails_large_objects_bytes       = 0
-    , gcdetails_compact_bytes             = 0
-    , gcdetails_slop_bytes                = 0
-    , gcdetails_mem_in_use_bytes          = 0
-    , gcdetails_copied_bytes              = 0
-    , gcdetails_par_max_copied_bytes      = 0
+    { gcdetails_gen                          = 0
+    , gcdetails_threads                      = 0
+    , gcdetails_allocated_bytes              = 0
+    , gcdetails_live_bytes                   = 0
+    , gcdetails_large_objects_bytes          = 0
+    , gcdetails_compact_bytes                = 0
+    , gcdetails_slop_bytes                   = 0
+    , gcdetails_mem_in_use_bytes             = 0
+    , gcdetails_copied_bytes                 = 0
+    , gcdetails_par_max_copied_bytes         = 0
 # if MIN_VERSION_base(4,11,0)
-    , gcdetails_par_balanced_copied_bytes = 0
+    , gcdetails_par_balanced_copied_bytes    = 0
 # endif
-    , gcdetails_sync_elapsed_ns           = 0
-    , gcdetails_cpu_ns                    = 0
-    , gcdetails_elapsed_ns                = 0
+    , gcdetails_sync_elapsed_ns              = 0
+    , gcdetails_cpu_ns                       = 0
+    , gcdetails_elapsed_ns                   = 0
+# if MIN_VERSION_base(4,14,0)
+# if MIN_VERSION_base(4,18,0)
+    , gcdetails_block_fragmentation_bytes    = 0
+# endif
+    , gcdetails_nonmoving_gc_sync_cpu_ns     = 0
+    , gcdetails_nonmoving_gc_sync_elapsed_ns = 0
+# endif
     }
 #else
 -- | Get GC statistics.

--- a/ekg-core.cabal
+++ b/ekg-core.cabal
@@ -1,20 +1,28 @@
-cabal-version:       3.0
-name:                ekg-core
-version:             0.1.2.0
-synopsis:            Tracking of system metrics
-description:
-  This library lets you define and track system metrics.
-homepage:            https://github.com/tibbe/ekg-core
-bug-reports:         https://github.com/tibbe/ekg-core/issues
-license:             BSD-3-Clause
-license-file:        LICENSE
-author:              Johan Tibell
-maintainer:          Johan Tibell <johan.tibell@gmail.com>,
-                     Mikhail Glushenkov <mikhail.glushenkov@gmail.com>
-category:            System
-build-type:          Simple
-extra-source-files:  CHANGES.md
-tested-with:         GHC == { 9.8.1, 9.6.3, 9.2.8, 8.10.7, 8.8.4, 8.6.5, 8.4.4 }
+cabal-version:      3.0
+name:               ekg-core
+version:            0.1.2.0
+synopsis:           Tracking of system metrics
+description:        This library lets you define and track system metrics.
+homepage:           https://github.com/tibbe/ekg-core
+bug-reports:        https://github.com/tibbe/ekg-core/issues
+license:            BSD-3-Clause
+license-file:       LICENSE
+author:             Johan Tibell
+maintainer:
+  Johan Tibell <johan.tibell@gmail.com>,
+  Mikhail Glushenkov <mikhail.glushenkov@gmail.com>
+
+category:           System
+build-type:         Simple
+extra-source-files: CHANGES.md
+tested-with:
+  GHC ==8.4.4
+   || ==8.6.5
+   || ==8.8.4
+   || ==8.10.7
+   || ==9.2.8
+   || ==9.6.3
+   || ==9.8.1
 
 library
   exposed-modules:
@@ -31,41 +39,46 @@ library
     System.Metrics.ThreadId
 
   build-depends:
-    ghc-prim             >=0.5.2 && < 0.12,
-    base                 >= 4.6 && < 4.20,
-    containers           >= 0.5 && < 0.7,
-    text                 >=1.2.4 && < 2.2,
-    unordered-containers < 0.3
+    , base                  >=4.6   && <4.20
+    , containers            >=0.5   && <0.7
+    , ghc-prim              >=0.5.2 && <0.12
+    , text                  >=1.2.4 && <2.2
+    , unordered-containers  <0.3
 
-  default-language:    Haskell2010
+  default-language: Haskell2010
+  ghc-options:      -Wall
 
-  ghc-options: -Wall
   if arch(i386)
     cc-options: -march=i686
-  includes: distrib.h
+
+  includes:         distrib.h
   install-includes: distrib.h
-  include-dirs: cbits
-  c-sources: cbits/atomic.c cbits/distrib.c
+  include-dirs:     cbits
+  c-sources:
+    cbits/atomic.c
+    cbits/distrib.c
 
 benchmark counter
-  main-is: Counter.hs
-  type: exitcode-stdio-1.0
+  main-is:          Counter.hs
+  type:             exitcode-stdio-1.0
   build-depends:
-    base,
-    ekg-core
+    , base
+    , ekg-core
+
   default-language: Haskell2010
-  hs-source-dirs: benchmarks
-  ghc-options: -O2 -threaded -Wall
+  hs-source-dirs:   benchmarks
+  ghc-options:      -O2 -threaded -Wall
 
 benchmark distribution
-  main-is: Distribution.hs
-  type: exitcode-stdio-1.0
+  main-is:          Distribution.hs
+  type:             exitcode-stdio-1.0
   build-depends:
-    base,
-    ekg-core
+    , base
+    , ekg-core
+
   default-language: Haskell2010
-  hs-source-dirs: benchmarks
-  ghc-options: -O2 -threaded -Wall
+  hs-source-dirs:   benchmarks
+  ghc-options:      -O2 -threaded -Wall
 
 source-repository head
   type:     git

--- a/ekg-core.cabal
+++ b/ekg-core.cabal
@@ -1,12 +1,12 @@
-cabal-version:       1.18
+cabal-version:       3.0
 name:                ekg-core
-version:             0.1.1.7
+version:             0.1.2.0
 synopsis:            Tracking of system metrics
 description:
-  This library lets you defined and track system metrics.
+  This library lets you define and track system metrics.
 homepage:            https://github.com/tibbe/ekg-core
 bug-reports:         https://github.com/tibbe/ekg-core/issues
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Johan Tibell
 maintainer:          Johan Tibell <johan.tibell@gmail.com>,
@@ -14,9 +14,7 @@ maintainer:          Johan Tibell <johan.tibell@gmail.com>,
 category:            System
 build-type:          Simple
 extra-source-files:  CHANGES.md
-tested-with:         GHC == 8.10.1, GHC == 8.8.3, GHC == 8.6.5,
-                     GHC == 8.4.4,  GHC == 8.2.2, GHC == 8.0.2,
-                     GHC == 7.10.3, GHC == 7.8.4, GHC == 7.6.3
+tested-with:         GHC == { 9.8.1, 9.6.3, 9.2.8, 8.10.7, 8.8.4, 8.6.5, 8.4.4 }
 
 library
   exposed-modules:
@@ -33,10 +31,10 @@ library
     System.Metrics.ThreadId
 
   build-depends:
-    ghc-prim < 0.8,
-    base >= 4.6 && < 4.16,
-    containers >= 0.5 && < 0.7,
-    text < 1.3,
+    ghc-prim             >=0.5.2 && < 0.12,
+    base                 >= 4.6 && < 4.20,
+    containers           >= 0.5 && < 0.7,
+    text                 >=1.2.4 && < 2.2,
     unordered-containers < 0.3
 
   default-language:    Haskell2010


### PR DESCRIPTION
- Adds the missing fields in RTSStats and GCDetails surrounded by cpp
  ifs
- Prunes the dependency bounds to support GHC 8.4.4 - 9.8.1.
- Format the cabal file with `cabal-fmt`.